### PR TITLE
Update Revision M Nodata

### DIFF
--- a/src/stactools/palsar/cog.py
+++ b/src/stactools/palsar/cog.py
@@ -40,9 +40,10 @@ def cogify(tile_path: str, output_directory: str):
         else:
             band = var_split[2]
 
-        if int(var_split[1]) >= 19:
-            # NoData value changed in 2019? from 0 to 1
+        if int(var_split[1]) >= 17:
+            # NoData value changed in 2017 from 0 to 1, Revision M
             # TODO: mask band value of 0 is better for setting NoData
+            # TODO: deduplicate with stac.py
             nodata_by_band = {
                 "HH": 1,
                 "HV": 1,


### PR DESCRIPTION
**Related Issue(s):**
#24 

**Description:**
Updated the COG conversion to match the metadata. Later TODO, convert to COG then read the Nodata value for the STAC records rather than having the Nodata dictionary twice. This applies to 2017 and later years in Revision M.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
